### PR TITLE
Fix installation with cargo typo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ ARGS:
 
 ## Installation
 ```sh
-$ cargo add changelog
+$ cargo install changelog
 ```
 
 ## License


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request 😄 ! Before you submit, please read the following:
- Read our CONTRIBUTING.md file before submitting a patch.
- By making a contribution, you agree to our Developer Certificate of Origin.
-->

**Choose one:** is this a 🐛 bug fix

## Checklist
- [x] documentation is changed or added

note: installing with cargo (on clean installed Windows 10; on the crate privdrop) already fails; but this has nothing to do with this PR; this PR merely contains a small typo fix for installation with `cargo` 

## Context
Issue #4.
Install `changelog` with `cargo` by doing `cargo install`, instead of`cargo add` which doesn't exist by default.
I wasn't sure whether you also wanted an issue linked to the PR, so I created one :-). 


## Semver Changes
"patch" if any
