### PR TITLE
fix commit link

### DIFF
--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -18,7 +18,7 @@ pub fn format(tag: &Tag, commits: &[Commit], repo_url: &str) -> String {
   for commit in commits {
     let long_hash = commit.hash();
     let short_hash = truncate(long_hash, 10);
-    let url = format!("{}/commits/{}", repo_url, long_hash);
+    let url = format!("{}/commit/{}", repo_url, long_hash);
     let hash = format!("[`{}`]({})", short_hash, url);
 
     let msg: Vec<&str> = commit.message().split("\n").collect();


### PR DESCRIPTION
Links to [`/commit`](https://github.com/datrs/random-access-memory/commit/3baa7c2d23dfa774ac5e1d2b38bbb171eaf95bc0) instead of [`/commits`](https://github.com/datrs/random-access-memory/commits/3baa7c2d23dfa774ac5e1d2b38bbb171eaf95bc0). Thanks!