### PR TITLE
Support Lightweight Tags and repos with a single tag

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -127,7 +127,6 @@ pub fn get_commit_range<'r>(repo: &'r Repository) -> ::Result<CommitRange<'r>> {
       name: Some(start_str.to_owned()),
     },
   };
-  println!("{:?}", cr);
 
   return Ok(cr);
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -75,7 +75,7 @@ pub fn diff(
   let tree2 = o2.tree().context(::ErrorKind::Git)?;
   // If o2 is the first object then we want to include it in the diff
   // so we diff o1 with None
-  let t2 = match o2.parent(1) {
+  let t2 = match o2.parent(0) {
     Err(_err) => None,
     Ok(_parent) => Some(&tree2),
   };
@@ -156,7 +156,7 @@ pub fn all_commits(path: &str) -> ::Result<(Tag, Vec<Commit>)> {
   let start = commit_range.start;
   let end = commit_range.end;
 
-  let end_is_first_commit = match end.parent(1) {
+  let end_is_first_commit = match end.parent(0) {
     Err(_err) => true,
     _ => false,
   };


### PR DESCRIPTION
This a 🐛 bug fix for #10 

Changes:
 - A new CommitRange struct is used for keeping track of the two commit and latest tag name
 - start and end are now expected to be Commits, not Objects
 - There is some new logic to include the end commit if it's the initial commit in the repo

Recommended SemVer change: patch

---

@yoshuawuyts Do you have any good ideas on how to test this? I've been using a few sample repos on my desktop but it would be nice if there was something more automated. Please let me know what you think of the changes so far 👍 

## Todo
- [ ] Dedupe initial commit logic (move it to the CommitRange struct?)
- [ ] Tests?
